### PR TITLE
Pin footer to bottom on diary entry pages

### DIFF
--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -218,9 +218,9 @@
                                     </div>
                                 </nav>
                             </div>
-                            <xsl:call-template name="html_footer"/>
                         </div>
                     </div>
+                    <xsl:call-template name="html_footer"/>
                 </div>
                 <!-- Modal Entitäten -->
                 <div class="modal fade" id="entitaeten" tabindex="-1"


### PR DESCRIPTION
Fixes #53

## Problem
On diary entry pages (`editions.xsl`) the footer floated up under the text on short entries instead of sticking to the bottom of the viewport.

## Cause
The sticky-footer mechanism is already wired up in CSS:
- `body` is a flex container with `min-height: 100vh` ([style.css:100-105](../blob/main/html/css/style.css#L100-L105))
- `.site` (`#page`) is a flex-grow column ([style.css:120-126](../blob/main/html/css/style.css#L120-L126))
- `#wrapper-footer-full` has `margin-top: auto` to absorb leftover space ([style.css:181-187](../blob/main/html/css/style.css#L181-L187))

For this to work the footer must be a **direct child of `.site`** — which it is on every page template (index, toc, calendar, listperson/place/work, imprint, meta, search) **except** `editions.xsl`, where it was nested inside `.container-fluid > .wp-transcript`. Nested, `margin-top: auto` had no free space to push against.

## Fix
Move the `html_footer` call out to be a direct child of `#page`, matching every other page. No CSS changes needed.

Since the diary entries are the main (16k+) page type, this is the most visible occurrence of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)