### PR TITLE
Move secondary menu into green action bar at top

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -469,6 +469,56 @@ h5 {
     color: white;
 }
 
+/* Action-Bar (zweites Menü unter der Navbar) */
+.action-bar {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+    background: #037A33;
+    color: #fff;
+    border-bottom: 1px solid #025c27;
+}
+.action-bar .inner {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 0 22px;
+    display: flex;
+    align-items: stretch;
+    flex-wrap: wrap;
+    gap: 0;
+}
+.action-bar a {
+    background: transparent;
+    border: none;
+    color: #fff;
+    padding: 11px 14px;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: .02em;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    transition: background .12s;
+}
+.action-bar a:hover {
+    background: rgba(255, 255, 255, .1);
+    color: #fff;
+    text-decoration: none;
+}
+.action-bar .fas,
+.action-bar .far {
+    color: #fff;
+}
+.action-bar .gap {
+    flex: 1;
+}
+.action-bar .neighbors {
+    display: inline-flex;
+    align-items: stretch;
+}
+
 p {
     display: block;
 }

--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -136,87 +136,67 @@
                 </div>
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
+                    <!-- Zweites Menü: breiter Balken in Projekt-Farbe direkt unter der Navbar -->
+                    <nav class="action-bar" id="actionBar"
+                        aria-label="Werkzeuge und Blättern">
+                        <div class="inner">
+                            <a href="#" data-bs-target="#entitaeten" data-bs-toggle="modal"
+                                title="Entitäten in diesem Eintrag">
+                                <i class="fas fa-sharp fa-solid fa-people-group"/>
+                                <xsl:text> Entitäten</xsl:text>
+                            </a>
+                            <a href="#" data-bs-target="#zitat" data-bs-toggle="modal"
+                                title="Zitiervorschlag zu diesem Eintrag">
+                                <i class="fas fa-quote-right"/>
+                                <xsl:text> Zitieren</xsl:text>
+                            </a>
+                            <a href="#" data-bs-target="#faks-modal" data-bs-toggle="modal"
+                                title="Faksimile zu diesem Eintrag">
+                                <i class="fa-lg far fa-file-image"/>
+                                <xsl:text> Faksimile</xsl:text>
+                            </a>
+                            <a href="#" data-bs-target="#downloadModal" data-bs-toggle="modal"
+                                title="Diesen Eintrag herunterladen">
+                                <i class="fas fa-solid fa-download"/>
+                                <xsl:text> Download</xsl:text>
+                            </a>
+                            <a href="#" data-bs-target="#schnitzler-chronik-modal"
+                                data-bs-toggle="modal" title="Weitere Ereignisse an diesem Tag">
+                                <i class="fas fa-calendar-day"/>
+                                <xsl:text> Chronik</xsl:text>
+                            </a>
+                            <span class="gap"/>
+                            <span class="neighbors">
+                                <xsl:if test="ends-with($prev, '.html')">
+                                    <a href="{$prev}" title="vorheriger Eintrag"
+                                        aria-label="vorheriger Eintrag">
+                                        <i class="fas fa-chevron-left"/>
+                                    </a>
+                                </xsl:if>
+                                <xsl:if test="ends-with($next, '.html')">
+                                    <a href="{$next}" title="nächster Eintrag"
+                                        aria-label="nächster Eintrag">
+                                        <i class="fas fa-chevron-right"/>
+                                    </a>
+                                </xsl:if>
+                            </span>
+                        </div>
+                    </nav>
                     <div class="container-fluid">
                         <div class="wp-transcript">
                             <div class="card" data-index="true">
                                 <div class="card-header">
                                     <div class="row">
-                                        <div class="col-md-2">
-                                            <xsl:if test="ends-with($prev, '.html')">
-                                                <h2>
-                                                  <a>
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="$prev"/>
-                                                  </xsl:attribute>
-                                                  <i class="fas fa-chevron-left" title="prev"/>
-                                                  </a>
-                                                </h2>
-                                            </xsl:if>
-                                        </div>
-                                        <div class="col-md-8">
+                                        <div class="col-md-12">
                                             <h1 align="center">
                                                 <xsl:value-of select="$doc_title"/>
                                             </h1>
-                                        </div>
-                                        <div class="col-md-2" style="text-align:right">
-                                            <xsl:if test="ends-with($next, '.html')">
-                                                <h1>
-                                                  <a>
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="$next"/>
-                                                  </xsl:attribute>
-                                                  <i class="fas fa-chevron-right" title="next"/>
-                                                  </a>
-                                                </h1>
-                                            </xsl:if>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="card-body-normalertext" data-index="true">
                                     <xsl:apply-templates select=".//tei:body"/>
                                 </div>
-                            </div>
-                            <div class="card-footer" style="clear: both;">
-                                <nav class="navbar navbar-expand-lg" style="box-shadow: none;">
-                                    <div class="container-fluid" style="display: flex;
-                                        justify-content: center;
-                                        align-items: center;">
-                                        <div id="navbarSupportedContent">
-                                            <ul class="navbar-nav mb-2 mb-lg-0" id="secondary-menu">
-                                                <li class="nav-item"> &#160;<a href="#"
-                                                  data-bs-target="#entitaeten" type="button"
-                                                  data-bs-toggle="modal"
-                                                  title="Entitäten in diesem Eintrag">
-                                                  <i class="fas fa-sharp fa-solid fa-people-group"/>
-                                                  ENTITÄTEN </a>&#160; </li>
-                                                <li class="nav-item"> &#160;<a href="#"
-                                                  data-bs-target="#zitat" type="button"
-                                                  data-bs-toggle="modal"
-                                                  title="Zitiervorschlag zu diesem Eintrag">
-                                                  <i class="fas fa-quote-right"/> ZITIEREN
-                                                  </a>&#160; </li>
-                                                <li class="nav-item"> &#160; <a href="#"
-                                                  title="Faksimile zu diesem Eintrag"
-                                                  data-bs-toggle="modal" type="button"
-                                                  data-bs-target="#faks-modal">
-                                                  <i class="fa-lg far fa-file-image"/> FAKSIMILE
-                                                  </a>&#160; </li>
-                                                <li class="nav-item"> &#160;<a href="#"
-                                                  data-bs-target="#downloadModal" type="button"
-                                                  data-bs-toggle="modal"
-                                                  title="Diesen Eintrag herunterladen"><i
-                                                  class="fas fa-solid fa-download"/> DOWNLOAD
-                                                  </a>&#160; </li>
-                                                <li class="nav-item"> &#160;<a href="#"
-                                                  data-bs-target="#schnitzler-chronik-modal"
-                                                  type="button" data-bs-toggle="modal"
-                                                  title="Weitere Ereignisse an diesem Tag">
-                                                  <i class="fas fa-calendar-day"/> CHRONIK
-                                                  </a>&#160; </li>
-                                            </ul>
-                                        </div>
-                                    </div>
-                                </nav>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
Adopts the secondary-menu placement from `schnitzler-briefe-static`. The secondary menu now appears as a wide, sticky **action bar directly under the navbar**, in the project color **green (`#037A33`)**, instead of in the card footer at the bottom of the page.

## Changes
- **`xslt/editions.xsl`**: The tool menu (Entitäten, Zitieren, Faksimile, Download, Chronik) moves from the bottom `card-footer` to a `<nav class="action-bar">` right below the navbar. Prev/next navigation arrows move into the right side of that same bar; the card header now holds only the centered title. Modal functionality is unchanged (Tagebuch keeps its modals rather than the briefe drawer system).
- **`html/css/style.css`**: New `.action-bar` styling analogous to briefe-static but in the project green, sticky at the top.

## Notes
- Menu labels are now in normal case ("Entitäten", "Zitieren" …) instead of all-caps, matching the briefe action-bar style.
- Verified with a local Saxon transform of a single diary entry — renders without errors.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)