### PR TITLE
Replace menu modals with drawer panels (keep Faksimile modal)

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -487,7 +487,8 @@ h5 {
     flex-wrap: wrap;
     gap: 0;
 }
-.action-bar a {
+.action-bar a,
+.action-bar button {
     background: transparent;
     border: none;
     color: #fff;
@@ -502,10 +503,28 @@ h5 {
     text-decoration: none;
     transition: background .12s;
 }
-.action-bar a:hover {
+.action-bar a:hover,
+.action-bar button:hover {
     background: rgba(255, 255, 255, .1);
     color: #fff;
     text-decoration: none;
+}
+.action-bar button[data-drawer]::after {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-right: 1.5px solid rgba(255, 255, 255, .75);
+    border-bottom: 1.5px solid rgba(255, 255, 255, .75);
+    transform: rotate(45deg);
+    margin-top: -4px;
+    transition: transform .15s;
+}
+.action-bar button[aria-expanded="true"] {
+    background: rgba(255, 255, 255, .18);
+}
+.action-bar button[data-drawer][aria-expanded="true"]::after {
+    transform: rotate(225deg);
+    margin-top: 4px;
 }
 .action-bar .fas,
 .action-bar .far {
@@ -517,6 +536,161 @@ h5 {
 .action-bar .neighbors {
     display: inline-flex;
     align-items: stretch;
+}
+
+/* Drawer unter der Action-Bar */
+.drawer-backdrop {
+    display: none;
+}
+.action-drawer {
+    background: #f5f5f5;
+    border-bottom: 1px solid #dee2e6;
+    display: none;
+    position: sticky;
+    top: 43px;
+    z-index: 1019;
+    box-shadow: 0 6px 18px -8px rgba(0, 0, 0, .1);
+}
+.action-drawer.open {
+    display: block;
+}
+.drawer-inner {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 22px 28px 26px;
+    max-height: 75vh;
+    overflow-y: auto;
+}
+.drawer-panel {
+    display: none;
+}
+.drawer-panel.active {
+    display: block;
+}
+.drawer-panel h3 {
+    font-size: 12px;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: #037A33;
+    font-weight: 700;
+    margin: 0 0 14px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid #037A33;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.drawer-panel h3 .close {
+    color: #5f676e;
+    font-weight: 500;
+    letter-spacing: 0;
+    text-transform: none;
+    font-size: 12px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    float: none;
+    opacity: 1;
+}
+.drawer-panel h3 .close:hover {
+    color: #037A33;
+}
+.drawer-panel ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+.drawer-panel ul li {
+    padding: 2px 0;
+}
+.drawer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px 24px;
+}
+.meta-caption {
+    font-size: 11px;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: #5f676e;
+    font-weight: 600;
+    margin: 0 0 8px;
+}
+.cite-block {
+    font-size: 15px;
+    line-height: 1.55;
+    padding: 14px 18px;
+    background: #f8f9fa;
+    border-left: 3px solid #037A33;
+    border-radius: 3px;
+    margin: 6px 0 16px;
+}
+.download-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.download-list a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 14px;
+    background: #037A33;
+    color: #fff;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+}
+.download-list a.secondary {
+    background: #fff;
+    color: #037A33;
+    border: 1px solid rgba(3, 122, 51, .4);
+}
+.download-list a:hover {
+    filter: brightness(1.05);
+}
+.download-list a .far,
+.download-list a .fas {
+    color: inherit;
+}
+
+/* Action-Bar und Drawer auf kleinen Bildschirmen */
+@media (max-width: 768px) {
+    .action-bar .inner {
+        padding: 0 10px;
+    }
+    .action-bar a,
+    .action-bar button {
+        padding: 9px 8px;
+        font-size: 12px;
+        gap: 5px;
+    }
+    .drawer-backdrop.show {
+        display: block;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, .35);
+        z-index: 1018;
+    }
+    .drawer-inner {
+        padding: 0 14px 18px;
+        max-height: calc(100vh - 160px);
+    }
+    .drawer-panel h3 {
+        position: sticky;
+        top: 0;
+        background: #f5f5f5;
+        z-index: 2;
+        padding-top: 12px;
+    }
+    .drawer-panel h3 .close {
+        font-size: 13px;
+        padding: 6px 0 6px 12px;
+    }
+    .drawer-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 p {

--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -249,8 +249,10 @@
                                     style="cursor: pointer; user-select: all;"
                                     title="Klicken zum Kopieren"
                                     onclick="navigator.clipboard.writeText(this.innerText)"> Arthur
-                                    Schnitzler: Tagebuch. Digitale Edition, <xsl:value-of
-                                        select="$doctitle"/>,
+                                    Schnitzler: Tagebuch 1879–1931. Digitale Ausgabe. Herausgegeben
+                                    von Austrian Centre for Digital Humanities (ACDH) der
+                                    Österreichischen Akademie der Wissenschaften. Wien, 2021.
+                                        <xsl:value-of select="$doctitle"/>,
                                     https://schnitzler-tagebuch.acdh.oeaw.ac.at/entry__<xsl:value-of
                                         select="descendant::tei:teiHeader[1]/tei:fileDesc[1]/tei:titleStmt[1]/tei:title[@type = 'iso-date']"
                                     />.html (Stand <xsl:value-of select="$currentDate"/>), PID:

--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -140,31 +140,32 @@
                     <nav class="action-bar" id="actionBar"
                         aria-label="Werkzeuge und Blättern">
                         <div class="inner">
-                            <a href="#" data-bs-target="#entitaeten" data-bs-toggle="modal"
+                            <button type="button" data-drawer="entitaeten" aria-expanded="false"
                                 title="Entitäten in diesem Eintrag">
                                 <i class="fas fa-sharp fa-solid fa-people-group"/>
                                 <xsl:text> Entitäten</xsl:text>
-                            </a>
-                            <a href="#" data-bs-target="#zitat" data-bs-toggle="modal"
+                            </button>
+                            <button type="button" data-drawer="cite" aria-expanded="false"
                                 title="Zitiervorschlag zu diesem Eintrag">
                                 <i class="fas fa-quote-right"/>
                                 <xsl:text> Zitieren</xsl:text>
-                            </a>
+                            </button>
+                            <!-- Faksimile bleibt ein Modal (OpenSeadragon-Viewer) -->
                             <a href="#" data-bs-target="#faks-modal" data-bs-toggle="modal"
                                 title="Faksimile zu diesem Eintrag">
                                 <i class="fa-lg far fa-file-image"/>
                                 <xsl:text> Faksimile</xsl:text>
                             </a>
-                            <a href="#" data-bs-target="#downloadModal" data-bs-toggle="modal"
+                            <button type="button" data-drawer="download" aria-expanded="false"
                                 title="Diesen Eintrag herunterladen">
                                 <i class="fas fa-solid fa-download"/>
                                 <xsl:text> Download</xsl:text>
-                            </a>
-                            <a href="#" data-bs-target="#schnitzler-chronik-modal"
-                                data-bs-toggle="modal" title="Weitere Ereignisse an diesem Tag">
+                            </button>
+                            <button type="button" data-drawer="chronik" aria-expanded="false"
+                                title="Weitere Ereignisse an diesem Tag">
                                 <i class="fas fa-calendar-day"/>
                                 <xsl:text> Chronik</xsl:text>
-                            </a>
+                            </button>
                             <span class="gap"/>
                             <span class="neighbors">
                                 <xsl:if test="ends-with($prev, '.html')">
@@ -182,6 +183,147 @@
                             </span>
                         </div>
                     </nav>
+                    <!-- Drawer, der unter der Action-Bar aufklappt -->
+                    <div class="drawer-backdrop" id="drawerBackdrop"/>
+                    <div class="action-drawer" id="drawer" role="region" aria-label="Werkzeuge">
+                        <div class="drawer-inner">
+                            <!-- ENTITÄTEN -->
+                            <div class="drawer-panel" data-panel="entitaeten">
+                                <h3>Erwähnte Entitäten <button type="button" class="close"
+                                        data-close="">schließen ✕</button></h3>
+                                <div class="drawer-grid">
+                                    <xsl:if test="//tei:back/tei:listPerson/tei:person[1]">
+                                        <div>
+                                            <div class="meta-caption">Personen</div>
+                                            <ul>
+                                                <xsl:for-each
+                                                  select="descendant::tei:back/tei:listPerson/tei:person">
+                                                  <li>
+                                                  <a href="{concat(data(@xml:id), '.html')}">
+                                                  <xsl:value-of select="child::tei:persName[1]"/>
+                                                  </a>
+                                                  </li>
+                                                </xsl:for-each>
+                                            </ul>
+                                        </div>
+                                    </xsl:if>
+                                    <xsl:if test=".//tei:back/tei:listBibl/tei:bibl[1]">
+                                        <div>
+                                            <div class="meta-caption">Werke</div>
+                                            <ul>
+                                                <xsl:for-each
+                                                  select="descendant::tei:back/tei:listBibl/tei:bibl">
+                                                  <li>
+                                                  <a href="{concat(data(@xml:id), '.html')}">
+                                                  <xsl:value-of select="tei:title[@type = 'main'][1]"/>
+                                                  </a>
+                                                  </li>
+                                                </xsl:for-each>
+                                            </ul>
+                                        </div>
+                                    </xsl:if>
+                                    <xsl:if test="//tei:back/tei:listPlace/tei:place[1]">
+                                        <div>
+                                            <div class="meta-caption">Orte</div>
+                                            <ul>
+                                                <xsl:for-each
+                                                  select="descendant::tei:back/tei:listPlace/tei:place">
+                                                  <li>
+                                                  <a href="{concat(data(@xml:id), '.html')}">
+                                                  <xsl:value-of
+                                                  select="child::tei:placeName[1]/text()"/>
+                                                  </a>
+                                                  </li>
+                                                </xsl:for-each>
+                                            </ul>
+                                        </div>
+                                    </xsl:if>
+                                </div>
+                            </div>
+                            <!-- ZITIEREN -->
+                            <div class="drawer-panel" data-panel="cite">
+                                <h3>Zitieren <button type="button" class="close" data-close=""
+                                        >schließen ✕</button></h3>
+                                <div class="meta-caption">Empfohlene Zitierweise</div>
+                                <blockquote class="cite-block"
+                                    style="cursor: pointer; user-select: all;"
+                                    title="Klicken zum Kopieren"
+                                    onclick="navigator.clipboard.writeText(this.innerText)"> Arthur
+                                    Schnitzler: Tagebuch. Digitale Edition, <xsl:value-of
+                                        select="$doctitle"/>,
+                                    https://schnitzler-tagebuch.acdh.oeaw.ac.at/entry__<xsl:value-of
+                                        select="descendant::tei:teiHeader[1]/tei:fileDesc[1]/tei:titleStmt[1]/tei:title[@type = 'iso-date']"
+                                    />.html (Stand <xsl:value-of select="$currentDate"/>), PID:
+                                        <xsl:value-of select="$pid"/>. </blockquote>
+                            </div>
+                            <!-- DOWNLOAD -->
+                            <div class="drawer-panel" data-panel="download">
+                                <h3>Download <button type="button" class="close" data-close=""
+                                        >schließen ✕</button></h3>
+                                <div class="download-list">
+                                    <xsl:choose>
+                                        <xsl:when test="$source-double-page = true()">
+                                            <a href="{$source1_pdf}" data-bs-toggle="tooltip"
+                                                title="Eintrag als PDF">
+                                                <i class="far fa-file-pdf"/>
+                                                <xsl:text> PDF (Seite 1)</xsl:text>
+                                            </a>
+                                            <a href="{$source2_pdf}" data-bs-toggle="tooltip"
+                                                title="Eintrag als PDF">
+                                                <i class="far fa-file-pdf"/>
+                                                <xsl:text> PDF (Seite 2)</xsl:text>
+                                            </a>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <a href="{$source1_pdf}" data-bs-toggle="tooltip"
+                                                title="Eintrag als PDF">
+                                                <i class="far fa-file-pdf"/>
+                                                <xsl:text> PDF</xsl:text>
+                                            </a>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                    <a class="secondary"
+                                        href="{concat(replace($teiSource, '.xml', ''), '.xml')}"
+                                        data-bs-toggle="tooltip" title="Eintrag als TEI-Datei">
+                                        <i class="far fa-file-code"/>
+                                        <xsl:text> TEI-XML</xsl:text>
+                                    </a>
+                                </div>
+                            </div>
+                            <!-- CHRONIK -->
+                            <div class="drawer-panel" data-panel="chronik">
+                                <xsl:variable name="datum"
+                                    select="descendant::tei:title[@type = 'iso-date']/text()"
+                                    as="xs:date"/>
+                                <h3>Chronik <button type="button" class="close" data-close=""
+                                        >schließen ✕</button></h3>
+                                <div id="chronik-modal-body"/>
+                                <!-- SCHNITZLER-CHRONIK. Zuerst wird der Eintrag geladen, weil das schneller ist, wenn er lokal vorliegt -->
+                                <xsl:variable name="fetchContentsFromURL" as="node()?">
+                                    <xsl:choose>
+                                        <xsl:when test="$schnitzler-chronik_fetch-locally">
+                                            <xsl:copy-of
+                                                select="document(concat('../chronik-data/', $datum, '.xml'))"/>
+                                            <!-- das geht davon aus, dass das schnitzler-chronik-repo lokal vorliegt -->
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:copy-of
+                                                select="document(concat('https://raw.githubusercontent.com/arthur-schnitzler/schnitzler-chronik-data/refs/heads/main/editions/data/', $datum, '.xml'))"
+                                            />
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:variable>
+                                <xsl:call-template name="mam:schnitzler-chronik">
+                                    <xsl:with-param name="datum-iso" select="$datum"/>
+                                    <xsl:with-param name="current-type"
+                                        select="$schnitzler-chronik_current-type"/>
+                                    <xsl:with-param name="teiSource" select="$teiSource"/>
+                                    <xsl:with-param name="fetchContentsFromURL"
+                                        select="$fetchContentsFromURL" as="node()?"/>
+                                </xsl:call-template>
+                            </div>
+                        </div>
+                    </div>
                     <div class="container-fluid">
                         <div class="wp-transcript">
                             <div class="card" data-index="true">
@@ -201,108 +343,6 @@
                         </div>
                     </div>
                     <xsl:call-template name="html_footer"/>
-                </div>
-                <!-- Modal Entitäten -->
-                <div class="modal fade" id="entitaeten" tabindex="-1"
-                    aria-labelledby="entitaetenModalLabel" aria-hidden="true">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="exampleModalLabel">Erwähnte
-                                    Entitäten</h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                    aria-label="Schließen"/>
-                            </div>
-                            <div class="modal-body">
-                                <div>
-                                    <xsl:if test="//tei:back/tei:listPerson/tei:person[1]">
-                                        <legend>Personen</legend>
-                                        <ul>
-                                            <xsl:for-each
-                                                select="descendant::tei:back/tei:listPerson/tei:person">
-                                                <li>
-                                                  <a>
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of
-                                                  select="concat(data(@xml:id), '.html')"/>
-                                                  </xsl:attribute>
-                                                  <xsl:value-of select="child::tei:persName[1]"/>
-                                                  </a>
-                                                </li>
-                                            </xsl:for-each>
-                                        </ul>
-                                    </xsl:if>
-                                </div>
-                                <div>
-                                    <xsl:if test=".//tei:back/tei:listBibl/tei:bibl[1]">
-                                        <legend>Werke</legend>
-                                        <ul>
-                                            <xsl:for-each
-                                                select="descendant::tei:back/tei:listBibl/tei:bibl">
-                                                <li>
-                                                  <a>
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of
-                                                  select="concat(data(@xml:id), '.html')"/>
-                                                  </xsl:attribute>
-                                                  <xsl:value-of
-                                                  select="tei:title[@type = 'main'][1]"/>
-                                                  </a>
-                                                </li>
-                                            </xsl:for-each>
-                                        </ul>
-                                    </xsl:if>
-                                </div>
-                                <div>
-                                    <xsl:if test="//tei:back/tei:listPlace/tei:place[1]">
-                                        <legend>Orte</legend>
-                                        <ul>
-                                            <xsl:for-each
-                                                select="descendant::tei:back/tei:listPlace/tei:place">
-                                                <li>
-                                                  <a>
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of
-                                                  select="concat(data(@xml:id), '.html')"/>
-                                                  </xsl:attribute>
-                                                  <xsl:value-of
-                                                  select="child::tei:placeName[1]/text()"/>
-                                                  </a>
-                                                </li>
-                                            </xsl:for-each>
-                                        </ul>
-                                    </xsl:if>
-                                </div>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary"
-                                    data-bs-dismiss="modal">Schließen</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Modal Zitat -->
-                <div class="modal fade" id="zitat" tabindex="-1" aria-labelledby="zitatModalLabel"
-                    aria-hidden="true">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="exampleModalLabel">Zitiervorschlag</h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                    aria-label="Schließen"/>
-                            </div>
-                            <div class="modal-body"> Arthur Schnitzler: Tagebuch. Digitale Edition,
-                                    <xsl:value-of select="$doctitle"/>,
-                                    https://schnitzler-tagebuch.acdh.oeaw.ac.at/entry__<xsl:value-of
-                                    select="descendant::tei:teiHeader[1]/tei:fileDesc[1]/tei:titleStmt[1]/tei:title[@type = 'iso-date']"
-                                />.html (Stand <xsl:value-of select="$currentDate"/>), PID:
-                                    <xsl:value-of select="$pid"/>. </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary"
-                                    data-bs-dismiss="modal">Schließen</button>
-                            </div>
-                        </div>
-                    </div>
                 </div>
                 <!-- Modal Faksimile -->
                 <div class="modal fade" id="faks-modal" tabindex="-1" aria-labelledby="faksimile"
@@ -439,108 +479,47 @@
                         </div>
                     </div>
                 </xsl:for-each>-->
-                <!-- Modal Download -->
-                <div class="modal fade" id="downloadModal" tabindex="-1"
-                    aria-labelledby="downloadModalLabel" aria-hidden="true">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="exampleModalLongTitle4"
-                                    >Downloadmöglichkeiten</h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                    aria-label="Schließen"/>
-                            </div>
-                            <div class="modal-body">
-                                <p>
-                                    <xsl:choose>
-                                        <xsl:when test="$source-double-page = true()">
-                                            <a class="ml-3" data-toggle="tooltip"
-                                                title="Eintrag als PDF">
-                                                <xsl:attribute name="href">
-                                                  <xsl:value-of select="$source1_pdf"/>
-                                                </xsl:attribute><xsl:text>&#160; </xsl:text>
-                                                <i class="fa-lg far fa-file-pdf"/>PDF </a>
-                                            <xsl:text>&#160; und </xsl:text>
-                                            <a class="ml-3" data-toggle="tooltip"
-                                                title="Eintrag als PDF">
-                                                <xsl:attribute name="href">
-                                                  <xsl:value-of select="$source2_pdf"/>
-                                                </xsl:attribute><xsl:text>&#160; </xsl:text>
-                                                <i class="fa-lg far fa-file-pdf"/>PDF </a>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <a class="ml-3" data-toggle="tooltip"
-                                                title="Eintrag als PDF">
-                                                <xsl:attribute name="href">
-                                                  <xsl:value-of select="$source1_pdf"/>
-                                                </xsl:attribute><xsl:text>&#160; </xsl:text>
-                                                <i class="fa-lg far fa-file-pdf"/>PDF </a>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </p>
-                                <p>
-                                    <a class="ml-3" data-toggle="tooltip"
-                                        title="Eintrag als TEI-Datei">
-                                        <xsl:attribute name="href">
-                                            <xsl:value-of
-                                                select="concat(replace($teiSource, '.xml', ''), '.xml')"
-                                            />
-                                        </xsl:attribute><xsl:text>&#160;</xsl:text>
-                                        <i class="fa-lg far fa-file-code"/>TEI </a>
-                                </p>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary"
-                                    data-bs-dismiss="modal">Schließen</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Modal Chronik -->
-                <div class="modal fade" id="schnitzler-chronik-modal" tabindex="-1"
-                    aria-labelledby="downloadModalLabel2" aria-hidden="true">
-                    <xsl:variable name="datum"
-                        select="descendant::tei:title[@type = 'iso-date']/text()" as="xs:date"/>
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <xsl:variable name="relevant-eventtypes" as="xs:string"
-                                select="string-join(document('../../schnitzler-chronik-static/xslt/export/list-of-relevant-uris.xml')/descendant::*:abbr[. != 'schnitzler-tagebuch'], ' ')"/>
-                            <!-- Achtung, kein Tagebuch, weil es ja keine zwei Einträge an einem Tag gibt -->
-                            <div class="modal-body">
-                                <div id="chronik-modal-body"/>
-                                <!-- SCHNITZLER-CHRONIK. Zuerst wird der Eintrag geladen, weil das schneller ist, wenn er lokal vorliegt -->
-                                <xsl:variable name="fetchContentsFromURL" as="node()?">
-                                    <xsl:choose>
-                                        <xsl:when test="$schnitzler-chronik_fetch-locally">
-                                            <xsl:copy-of
-                                                select="document(concat('../chronik-data/', $datum, '.xml'))"/>
-                                            <!-- das geht davon aus, dass das schnitzler-chronik-repo lokal vorliegt -->
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:copy-of
-                                                select="document(concat('https://raw.githubusercontent.com/arthur-schnitzler/schnitzler-chronik-data/refs/heads/main/editions/data/', $datum, '.xml'))"
-                                            />
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </xsl:variable>
-                                <xsl:call-template name="mam:schnitzler-chronik">
-                                    <xsl:with-param name="datum-iso" select="$datum"/>
-                                    <xsl:with-param name="current-type"
-                                        select="$schnitzler-chronik_current-type"/>
-                                    <xsl:with-param name="teiSource" select="$teiSource"/>
-                                    <xsl:with-param name="fetchContentsFromURL"
-                                        select="$fetchContentsFromURL" as="node()?"/>
-                                </xsl:call-template>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary"
-                                    data-bs-dismiss="modal">Schließen</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 <!--<script src="https://unpkg.com/de-micro-editor@0.2.6/dist/de-editor.min.js"/>-->
                 <!--<script type="text/javascript" src="js/run.js"/>-->
+                <script>
+// Action-Bar-Drawer (Entitäten, Zitieren, Download, Chronik)
+(function(){
+var bar=document.getElementById('actionBar');
+var drawer=document.getElementById('drawer');
+var backdrop=document.getElementById('drawerBackdrop');
+if(!bar||!drawer){return;}
+var buttons=bar.querySelectorAll('button[data-drawer]');
+var panels=drawer.querySelectorAll('.drawer-panel');
+function syncTop(){drawer.style.top=bar.offsetHeight+'px';}
+syncTop();
+window.addEventListener('resize',syncTop);
+if(window.ResizeObserver){new ResizeObserver(syncTop).observe(bar);}
+function openDrawer(name){
+syncTop();
+buttons.forEach(function(b){b.setAttribute('aria-expanded',b.getAttribute('data-drawer')===name?'true':'false');});
+panels.forEach(function(p){p.classList.toggle('active',p.getAttribute('data-panel')===name);});
+drawer.classList.add('open');
+if(backdrop){backdrop.classList.add('show');}
+var inner=drawer.querySelector('.drawer-inner');
+if(inner){inner.scrollTop=0;}
+document.dispatchEvent(new CustomEvent('drawer:open',{detail:name}));
+}
+function closeDrawer(){
+buttons.forEach(function(b){b.setAttribute('aria-expanded','false');});
+drawer.classList.remove('open');
+if(backdrop){backdrop.classList.remove('show');}
+}
+buttons.forEach(function(b){
+b.addEventListener('click',function(){
+var name=b.getAttribute('data-drawer');
+var expanded=b.getAttribute('aria-expanded')==='true';
+if(expanded){closeDrawer();}else{openDrawer(name);}
+});
+});
+drawer.querySelectorAll('[data-close]').forEach(function(c){c.addEventListener('click',closeDrawer);});
+if(backdrop){backdrop.addEventListener('click',closeDrawer);}
+document.addEventListener('keydown',function(e){if(e.key==='Escape'){closeDrawer();}});
+})();</script>
             </body>
         </html>
     </xsl:template>


### PR DESCRIPTION
## Summary
Follow-up to #73. Adopts the briefe-static interaction model for the secondary menu: instead of Bootstrap modals, **Entitäten, Zitieren, Download and Chronik** now open as panels in a drawer that slides down from the green action bar. **Faksimile keeps its modal** because of the OpenSeadragon viewer.

## Changes
- **`xslt/editions.xsl`**: action-bar items become `<button data-drawer="…">` (except Faksimile); added the drawer markup with migrated panel content (Entitäten, Zitieren, Download, Chronik) and the drawer toggle JS. Removed the now-redundant `#entitaeten`, `#zitat`, `#downloadModal` and `#schnitzler-chronik-modal` modals.
- **`html/css/style.css`**: green-themed drawer/panel styling (`.action-drawer`, `.drawer-panel`, `.meta-caption`, `.cite-block`, `.download-list`), button caret + open state, and mobile rules.

## Notes
- Verified with a local Saxon transform of a diary entry: all four panels render, only the Faksimile modal remains, the toggle JS and Chronik content are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)